### PR TITLE
fix: Update default category ID and enhance date range handling in category service

### DIFF
--- a/front/src/app/core/services/category/category.service.ts
+++ b/front/src/app/core/services/category/category.service.ts
@@ -5,6 +5,7 @@ import { CategoriesApiRequest } from '../../models/category/get-many.model';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { BasePagingResponse } from '../../models/api/paging.model';
+import { DateTime } from 'luxon';
 
 @Injectable({
   providedIn: 'root',
@@ -50,7 +51,14 @@ export class CategoryService {
   }
 
   getCategoriesList(request?: CategoriesApiRequest): Observable<BasePagingResponse<Category>> {
-    const params = new HttpParams({ fromObject: { sortDirection: 'DESC', ...request } });
+    const timeRange = {
+      from: DateTime.now().startOf('month'),
+      to: DateTime.now().endOf('month'),
+    };
+
+    const params = new HttpParams({
+      fromObject: { sortDirection: 'DESC', from: timeRange.from.toISO(), to: timeRange.to.toISO(), ...request },
+    });
 
     return this.httpClient.get<BasePagingResponse<Category>>(`${this.apiUrl}`, { params }).pipe(
       map((res) => ({

--- a/front/src/app/features/dashboard/components/add-bill-dialog/add-bill-dialog.component.ts
+++ b/front/src/app/features/dashboard/components/add-bill-dialog/add-bill-dialog.component.ts
@@ -46,7 +46,7 @@ export class AddBillDialogComponent implements OnInit {
     date: new FormControl<string>(DateTime.now().toISODate(), Validators.required),
     time: new FormControl<string>(DateTime.now().toFormat('HH:mm'), Validators.required),
     amount: new FormControl<number>(0, { validators: [Validators.required, Validators.min(0.01)] }),
-    categoryId: new FormControl<number | null>(null, { validators: [Validators.required] }),
+    categoryId: new FormControl<number | null>(1, { validators: [Validators.required] }),
     currencyId: new FormControl<number>(0, { validators: [Validators.required] }),
   });
 


### PR DESCRIPTION
Set the default category ID to 1 in the add bill dialog and improve date range handling by automatically setting the range to the current month in the category service.