### PR TITLE
fix: Refresh dashboard widgets after adding new bill via add-bill-dialog

### DIFF
--- a/front/src/app/features/dashboard/components/add-bill-dialog/add-bill-dialog.component.ts
+++ b/front/src/app/features/dashboard/components/add-bill-dialog/add-bill-dialog.component.ts
@@ -122,7 +122,7 @@ export class AddBillDialogComponent implements OnInit {
 
     this.billsService.addBill(billData).subscribe({
       complete: () => {
-        this.dialogRef.close();
+        this.dialogRef.close(true);
         this.submitting.set(false);
       },
       error: (err) => {

--- a/front/src/app/features/dashboard/components/base-widget/base-widget.component.ts
+++ b/front/src/app/features/dashboard/components/base-widget/base-widget.component.ts
@@ -1,4 +1,4 @@
-import { Observable, ReplaySubject, skip } from 'rxjs';
+import { combineLatest, Observable, ReplaySubject } from 'rxjs';
 import { IWidget, IWidgetConfig } from '../../../../core/models/statistics/widget';
 import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { TimeRange } from '../../../../core/models/time-range/time-range';
@@ -24,12 +24,14 @@ export abstract class BaseWidgetComponent implements IWidget, OnInit {
   destroyRef = inject(DestroyRef);
 
   ngOnInit() {
-    this.dashboardStore.timeRange$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((timeRange) => {
-      this.timeRange.set(timeRange);
-      this.onRefresh.next();
+    combineLatest([this.dashboardStore.timeRange$, this.dashboardStore.refresh$])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([timeRange]) => {
+        this.timeRange.set(timeRange);
+        this.onRefresh.next();
 
-      this.loadData();
-    });
+        this.loadData();
+      });
 
     this.loadData();
   }

--- a/front/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
+++ b/front/src/app/features/dashboard/pages/dashboard/dashboard.component.ts
@@ -71,12 +71,18 @@ export class DashboardComponent implements OnInit {
   );
 
   openAddBillDialog() {
-    this.dialog.open(AddBillDialogComponent, {
+    const dialogRef = this.dialog.open(AddBillDialogComponent, {
       width: '600px',
       data: {
         timeRange: this.timeRange(),
       },
       viewContainerRef: this.viewContainerRef,
+    });
+
+    dialogRef.afterClosed().subscribe((addedBill) => {
+      if (addedBill) {
+        this.dashboardState.refreshWidgets();
+      }
     });
   }
 }

--- a/front/src/app/features/dashboard/store/dashboard-state.store.ts
+++ b/front/src/app/features/dashboard/store/dashboard-state.store.ts
@@ -1,19 +1,33 @@
 import { Injectable } from '@angular/core';
 import { ComponentStore } from '@ngrx/component-store';
+import { tap } from 'rxjs/operators';
 import { EMPTY_DASHBOARD_STATE } from '../constants/empty-dasboard-state';
 import { TimeRange } from '../../../core/models/time-range/time-range';
 import { IDashboardState } from '../models/dashboard-state';
+import { Subject } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class DashboardStateStore extends ComponentStore<IDashboardState> {
+  private readonly refreshSubject = new Subject<void>();
+
   constructor() {
     super(EMPTY_DASHBOARD_STATE);
   }
 
   readonly timeRange$ = this.select((state) => state.timeRange);
 
+  readonly refresh$ = this.refreshSubject.asObservable();
+
   readonly setTimeRange = this.updater((state, timeRange: TimeRange) => ({
     ...state,
     timeRange,
   }));
+
+  readonly refreshWidgets = this.effect<void>((trigger$) =>
+    trigger$.pipe(
+      tap(() => {
+        this.refreshSubject.next();
+      }),
+    ),
+  );
 }


### PR DESCRIPTION
Improve the add bill dialog to close with a confirmation and update the dashboard state management to refresh widgets after adding a bill. Refactor the dashboard component to use combined observables for better state handling.